### PR TITLE
Fixed bug in SplitMeanNASC(), where now acoustic categories not to be…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.3.24
-Date: 2021-06-04
+Version: 1.3.25
+Date: 2021-06-09
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 
@@ -46,7 +46,7 @@ Imports:
     sf (>= 0.9.0),
     ggplot2 (>= 3.0.0),
     units (>= 0.7),
-    RstoxData (>= 1.1.10)
+    RstoxData (>= 1.1.14)
 Suggests: 
     testthat
 Additional_repositories: 

--- a/R/Acoustic.R
+++ b/R/Acoustic.R
@@ -244,13 +244,15 @@ SplitMeanNASC <- function(
         unique(MeanNASCData$Data$AcousticCategory), 
         unique(AcousticCategoryLink$AcousticCategory)
     )
-    AcousticCategoryLink <- rbind(
-        AcousticCategoryLink, 
-        data.table::data.table(
-            MixAcousticCategory = AcousticCategoryNotToBeSplit, 
-            SplitAcousticCategory = AcousticCategoryNotToBeSplit
+    if(lenght(AcousticCategoryNotToBeSplit)) {
+        AcousticCategoryLink <- rbind(
+            AcousticCategoryLink, 
+            data.table::data.table(
+                MixAcousticCategory = AcousticCategoryNotToBeSplit, 
+                SplitAcousticCategory = AcousticCategoryNotToBeSplit
+            )
         )
-    )
+    }
     
     # Copy the NASC from the MixAcousticCategory to the SplitAcousticCategory, and remove the MixAcousticCategory:
     MeanNASCDataToSplit <- subset(MeanNASCData$Data, AcousticCategory %in% AcousticCategoryLink$AcousticCategory)


### PR DESCRIPTION
… split are added to the AcousticCategoryLink only if of positive length.