### PR TITLE
Fixed the last bug in DistributionMethod == "HaulDensity", where Weig…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.3.29
-Date: 2021-06-14
+Version: 1.3.30
+Date: 2021-06-15
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 

--- a/R/Abundance.R
+++ b/R/Abundance.R
@@ -423,7 +423,10 @@ SuperIndividuals <- function(
         )
         
         # Sum the haul densities (stored as WeightedCount) over all hauls of each Stratum/Layer/SpeciesCategory/LengthGroup/Frequency/Beam:
-        SuperIndividualsData[, sumWeightedCount := sum(unique(WeightedCount), na.rm = TRUE), by = distributeAbundanceBy]
+        # No no, this was certainly wrong, as WeightedCount could be duplicated within a Stratum for one length group:
+        #SuperIndividualsData[, sumWeightedCount := sum(unique(WeightedCount), na.rm = TRUE), by = distributeAbundanceBy]
+        # Sum the WeightedCount over all hauls of the columns specified by distributeAbundanceBy:
+        SuperIndividualsData[, sumWeightedCount := sum(WeightedCount[!duplicated(Haul)], na.rm = TRUE), by = distributeAbundanceBy]
         
         # Get the Haul weight factor as the WeightedCount divided by sumWeightedCount:
         SuperIndividualsData[, haulWeightFactor := WeightedCount / sumWeightedCount]


### PR DESCRIPTION
…htedCount was summed over unique values insteaf of by unique Hauls.