### PR TITLE
Removed updating PSUByTime in DefineAcousticPSU() when UseProcessData…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.4.12
-Date: 2021-09-17
+Version: 1.4.13
+Date: 2021-09-28
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# RstoxBase v1.4.13 (2021-09-28)
+* Added the function SplitNASC() intended to replaec SplitMeanNASC(). SplitNASC() uses NASCData and AcousticPSU as input and generates one PSU per EDSU for splitting the NASC based on BioticAssignment, and then returns a NASCData object. Consequently one can skip the MeanNASC() function in the model. Added method for simplifying stratum polygons in DefineStratumPolygon. Fixed bug when using depth TargetStrengthMethod = "LengthAndDepthDependent" .
+* Sped up DefineAcousticPSU with DefinitionMethod "EDSUToPSU" by removing loop over EDSUs. Fixed bug when reading shapefiles or GeoJSON, by introducing the parameter StratumNameLabel in DefineStratumPolygon(). Added the option of simplifying stratum polygons by the new parameters SimplifyStratumPolygon and SimplificationFactor.
+* Removed updating PSUByTime in DefineAcousticPSU() when UseProcessData = TRUE, as this destroys the information to be passed onto another process using DefineAcousticPSU() where the first process is used as input.
+* Fixed bug where LengthDistribution produced a line of NA in IndividualTotalLength for subsamples that were completely empty by the filter, thus resulting in a small percentage of the WeightedCount assigned to this NA length in the percent length distribution, and consequently reducinng the WeightedCount of the valid lengths.
+* Changed from [0, Inf] to [min, max] of channel depth when DefinitionMethod "WaterColumn" in DefineLayer(), and added [0, Inf] if [min, max] are NA in channel depth when DefinitionMethod "WaterColumn" in DefineLayer().
+* Fixed bugs related to stratum names (using getStratumNames() consistently).
+* Added shapefile and GeoJSON to the tests.
+
 # RstoxBase v1.4.4 (2021-08-18)
 * Added more informative error when more than one SpeciesCategory in BioticAssignmentWeighting().
 * Fixed bug in SuperIndividuals() where length measured individuals were counted over all beams, whereas per beam was correct. Added DefinitionMethod "ResourceFile" in DefineSurvey(), DefineAcousticPSU() and DefineBioticAssignment(), and support for a StoX 2.7 project.xml file in DefineStratumPolygon().*

--- a/R/Define.R
+++ b/R/Define.R
@@ -112,14 +112,14 @@ DefinePSU <- function(
         # Rename back from "SSU" to "EDSU"/"Station": 
         processData <- renameSSULabelInPSUProcessData(processData, PSUType = PSUType, reverse = FALSE)
         
-        # Add the PSUByTime:
-        if(SavePSUByTime) {
-            processData$PSUByTime <- getPSUByTime(
-                PSUProcessData = processData, 
-                MergedStoxDataStationLevel = MergedStoxDataStationLevel, 
-                PSUType = PSUType
-            )
-        }
+        ## Add the PSUByTime:
+        #if(SavePSUByTime) {
+        #    processData$PSUByTime <- getPSUByTime(
+        #        PSUProcessData = processData, 
+        #        MergedStoxDataStationLevel = MergedStoxDataStationLevel, 
+        #        PSUType = PSUType
+        #    )
+        #}
         return(processData)
     }
     

--- a/R/Plot.R
+++ b/R/Plot.R
@@ -28,8 +28,8 @@ PlotNASC <- function(
     NASCData, 
     ColorScale = c("combined.color", "rainbow", "hcl.colors", "heat.colors", "terrain.colors", "topo.colors", "cm.colors"), 
     Zoom = 1, 
-    MinimumSize = 0, 
-    MaximumSize = 10, 
+    MinSize = 0, 
+    MaxSize = 10, 
     TrackOnTop = FALSE
 ) {
     
@@ -42,7 +42,7 @@ PlotNASC <- function(
         x = NASCData, 
         lon = "Longitude", lat = "Latitude", 
         type = if(TrackOnTop) "pl" else "lp", 
-        size = "NASC", size.track = 1, size.range = c(MinimumSize, MaximumSize), 
+        size = "NASC", size.track = 1, size.range = c(MinSize, MaxSize), 
         color = "NASC", color.track = 1, 
         color.scale = do.call(ColorScale, list(ncolors)), 
         shape = 19, 
@@ -82,8 +82,8 @@ PlotSumNASC <- function(
     SumNASCData, 
     ColorScale = c("combined.color", "rainbow", "hcl.colors", "heat.colors", "terrain.colors", "topo.colors", "cm.colors"), 
     Zoom = 1, 
-    MinimumSize = 0, 
-    MaximumSize = 10, 
+    MinSize = 0, 
+    MaxSize = 10, 
     TrackOnTop = FALSE
 ) {
     
@@ -96,7 +96,7 @@ PlotSumNASC <- function(
         x = SumNASCData$Data, 
         lon = "Longitude", lat = "Latitude", 
         type = if(TrackOnTop) "pl" else "lp", 
-        size = "NASC", size.track = 1, size.range = c(MinimumSize, MaximumSize), 
+        size = "NASC", size.track = 1, size.range = c(MinSize, MaxSize), 
         color = "NASC", color.track = 1, 
         color.scale = do.call(ColorScale, list(ncolors)), 
         shape = 19, 

--- a/R/RstoxBase-package.R
+++ b/R/RstoxBase-package.R
@@ -33,8 +33,9 @@ utils::globalVariables(c(
 	 "aggregationVariables", "assignmentID", "assignmentPasted", "backscatteringCrossSection",
 	 "crossSection", "distance", "functionName", "haulWeightFactor", "imputeSeed", "includeintotal",
 	 "individualCount", "individualWeightFactor", "inside", "intervalIndex", "midDepth",
-	 "midIndividualTotalLength", "minDistance", "multiple", "packageName", "projectXMLFilePath",
-	 "raisingFactor", "representativeBackscatteringCrossSection",
+	 "midIndividualTotalLength", "minDistance", "multiple", "numberOfIndividuals",
+	 "numberOfSubSamples", "packageName", "projectXMLFilePath", "raisingFactor",
+	 "representativeBackscatteringCrossSection",
 	 "representativeBackscatteringCrossSectionNormalized", "sd", "stratumPolygonFilePath",
 	 "sumIndividualWeightFactor", "sumWeightedCount", "weighted", "weightingParameter", "x", "y"))
 


### PR DESCRIPTION
… = TRUE, as this destroys the information to be passed onto another process using DefineAcousticPSU() where the first process is used as input.