### PR TITLE
Changed ImputeSuperIndividuals() to not add rows from EDSUs with no a…

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -95,20 +95,25 @@ jobs:
           brew install gdal
         shell: bash
 
-      - name: Install dependencies
+      - name: Install dependencies on Linux
+        if: runner.os == 'Linux'
         run: |
           remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+
+      - name: Install dependencies on Windows and macOS
+        if: runner.os != 'Linux'
+        run: |
+          remotes::install_deps(dependencies = TRUE, type = "binary")
+        shell: Rscript {0}
+
+      - name: Install CRANdependencies
+        run: |
           remotes::install_cran("rcmdcheck")
           remotes::install_cran("git2r")
           remotes::install_cran("drat")
         shell: Rscript {0}
         
-      - name: Install s2 on Windows
-        if: runner.os == 'Windows'
-        run: |
-          remotes::install_cran("s2", type = "binary")
-        shell: Rscript {0}
-
       - name: Session info
         run: |
           options(width = 100)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.4.15
-Date: 2021-10-05
+Version: 1.4.16
+Date: 2021-10-11
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# RstoxData v1.3.0 (2021-10-08)
+# RstoxData v1.4.16 (2021-10-11)
+
+* Changed ImputeSuperIndividuals() to not add rows from EDSUs with no assigned biotic hauls. In the previous version, rows were added with NA in all variables except those from the EDSU (frequency, etc.) if e.g. assignment method "Stratum" was used, and no hauls existed in a stratum with EDSUs.
+* Changed aggregateBaselineDataOneTable() so that when used to produce reports using RstoxFramework::BootstraReport() NAs are not change to 0 except for NAs introduced between bootstrap runs (e.g., ages missing in some runs due to resampling of hauls).
+* Fixed bug in the parameter formats of ImputeSuperIndividuals() when using SuperIndividualsData from another process using ImputeSuperIndividuals().
+
+# RstoxData v1.4.15 (2021-10-08)
 
 * Fixed bug in SplitNASC().
 * Final version for the release of StoX 3.2.0.

--- a/R/Abundance.R
+++ b/R/Abundance.R
@@ -193,7 +193,8 @@ SuperIndividuals <- function(
         by = mergeBy, 
         allow.cartesian = TRUE, 
         ### all.y = TRUE # Keep all stata, even those with no acoustic data of the requested species. Using all.y = TRUE will however delete the individuals assigned to PSUs in those strata. We rather use all = TRUE and deal with the NAs (explain the NAs from the data):
-        all = TRUE
+        # Changed from all =  TRUE to all.x = TRUE on 2021-10-08, since we do not want extra rows in the individuals from strata with no biology but with acoustics:
+        all.x = TRUE
     )
     
     # Append an individualCount to the SuperIndividualsData, representing the number of individuals in each category given by 'by':
@@ -529,6 +530,13 @@ ImputeSuperIndividuals <- function(
     keys <- names(ImputeSuperIndividualsData)[areKeys]
     #formatOutput(IndividualsData, dataType = "IndividualsData", keep.all = TRUE, secondaryColumnOrder = keys)
     formatOutput(ImputeSuperIndividualsData, dataType = "SuperIndividualsData", keep.all = TRUE, allow.missing = TRUE, secondaryColumnOrder = unlist(attr(SuperIndividualsData, "stoxDataVariableNames")), secondaryRowOrder = keys)
+    
+    # Add the attribute 'variableNames':
+    setattr(
+        ImputeSuperIndividualsData, 
+        "stoxDataVariableNames",
+        attr(SuperIndividualsData, "stoxDataVariableNames")
+    )
     
     # Not needed here, since we only copy data: 
     #Ensure that the numeric values are rounded to the defined number of digits:

--- a/R/Acoustic.R
+++ b/R/Acoustic.R
@@ -202,7 +202,7 @@ MeanNASC <- function(
 }
 
 ##################################################
-#' Split MeanNASCData to NASCData
+#' Split MeanNASCData to NASCData (deprecated)
 #' 
 #' This function splits NASCData of specific acoustic categories into other categories based on the acoustic target strength of these categories and the length distribution of corresponding species categories.
 #' 


### PR DESCRIPTION
…ssigned biotic hauls. Changed aggregateBaselineDataOneTable() so that when used to produce reports using RstoxFramework::BootstraReport() NAs are not change to 0 except for NAs introduced between bootstrap runs. Fixed bug in the parameter formats of ImputeSuperIndividuals() when using SuperIndividualsData from another process using ImputeSuperIndividuals().