### PR TITLE
Moved NumberOfAssignedHaulsWithCatch to before changing WeightedNumbe…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.5.4
-Date: 2022-01-12
+Version: 1.6.0
+Date: 2022-01-13
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 
@@ -50,7 +50,7 @@ Imports:
     methods (>= 3.6.2),
     xml2 (>= 1.2.2),
     stringi (>= 1.4.3),
-    RstoxData (>= 1.3.5)
+    RstoxData (>= 1.4.0)
 Suggests: 
     testthat
 Additional_repositories: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,7 +28,7 @@
 
 
 # RstoxBase v1.5.2 (2022-01-10)
-* Changed SpeciesCategoryCatch() to return a single table similar to LengthDistributionData, but with TotalCatchWeight and TotalCatchCount instead of WeightedCount. As such, moved the CatchVariable of SpeciesCategoryCatch() to the ReportVariable of ReportSpeciesCategoryCatch(). The latter is a backward compatibility breaking change.
+* Changed SpeciesCategoryCatch() to return a single table similar to LengthDistributionData, but with TotalCatchWeight and TotalCatchCount instead of WeightedCount. As such, moved the CatchVariable of SpeciesCategoryCatch() to the ReportVariable of ReportSpeciesCategoryCatch(). The latter is a backward compatibility breaking change. Any existing StoX project using SpeciesCategoryCatch() and ReportSpeciesCategoryCatch() will break in ReportSpeciesCategoryCatch(), and the ReportVariable needs to be set to the appropriate value in order to continue.
 * Added SumSpeciesCategoryCatch() and MeanSpeciesCategoryCatch().
 * Added the parameter SweptAreaDensityType in SweptAreaDensity() supporting both "LengthDistributed" and "TotalCatch" swept-area density. 
 * Added new column DensityType in DensityData with supported values "AreaNumberDensity" (the only option for AcousticDensity() and  SweptAreaDensityType "LengthDistributed") and  "AreaMassDensity".

--- a/R/Density.R
+++ b/R/Density.R
@@ -210,6 +210,7 @@ DistributeNASC <- function(
     resolution <- getDataTypeDefinition(dataType = "DensityData", elements = c("horizontalResolution", "verticalResolution"), unlist = TRUE)
     checkValidHaulsBy <- c(resolution, getDataTypeDefinition(dataType = "DensityData", elements = c("categoryVariable"), unlist = TRUE))
     notAllHaulsHaveCatch <- NASCData[, .(notAllHaulsHaveCatch = NumberOfAssignedHaulsWithCatch != NumberOfAssignedHauls), by = checkValidHaulsBy]
+    
     if(any(notAllHaulsHaveCatch$notAllHaulsHaveCatch, na.rm = TRUE)) {
         withInvalidHauls <- unique(NASCData[notAllHaulsHaveCatch$notAllHaulsHaveCatch, c(checkValidHaulsBy, "NumberOfAssignedHaulsWithCatch", "NumberOfAssignedHauls"),with = FALSE], by = checkValidHaulsBy)
         withInvalidHauls <- paste0(
@@ -538,7 +539,7 @@ SweptAreaDensity <- function(
 ##################################################
 #' Mean density in each stratum
 #' 
-#' This function calculates the weighted average of the density in each stratum (or possibly in each PSU, which impies returning the input DensityData unchanged). The weights are effective log distance for acoustic density and number of hauls ??????????????????? per PSU for swept area density.
+#' This function calculates the weighted average of the density in each stratum (or possibly in each PSU, which implies returning the input DensityData unchanged). The weights are effective log distance for acoustic density and number of stations per biotic PSU for swept area density.
 #' 
 #' @inheritParams ModelData
 #' 

--- a/R/LengthDistribution.R
+++ b/R/LengthDistribution.R
@@ -963,6 +963,12 @@ getAssignmentLengthDistributionDataOne <- function(assignmentPasted, LengthDistr
     WeightingFactors <- BioticAssignment$WeightingFactor
     thisLengthDistributionData <- subset(LengthDistributionData, Haul %in% Hauls)
     
+    # Add the number of assigned hauls par PSU, and the number of assigned hauls with length distribution for each species
+    thisLengthDistributionData[, NumberOfAssignedHauls := length(unique(Haul))]
+    thisLengthDistributionData[, HasAnyPositiveWeightedNumber := any(!is.na(get(dataVariable)) & (get(dataVariable) > 0) %in% TRUE), by = c("Haul", "SpeciesCategory")]
+    thisLengthDistributionData[, ValidHaul := ifelse(HasAnyPositiveWeightedNumber, Haul, NA)]
+    thisLengthDistributionData[, NumberOfAssignedHaulsWithCatch := length(unique(stats::na.omit(ValidHaul))), by = "SpeciesCategory"]
+    
     # Overwrite the weights by those defined in the BioticAssignment object:
     weightingVariable <- getDataTypeDefinition(dataType = "LengthDistributionData", elements = "weighting", unlist = TRUE)
     thisLengthDistributionData[, c(weightingVariable) := ..WeightingFactors[match(Haul, ..Hauls)]]
@@ -970,12 +976,6 @@ getAssignmentLengthDistributionDataOne <- function(assignmentPasted, LengthDistr
     # Get the category and grouping variables (SpeciesCategory, IndividualTotalLength, LengthResolution), and sum across hauls for each combination of these variables, weighted by the "WeightedNumber":
     by <- getDataTypeDefinition(dataType = "LengthDistributionData", elements = c("categoryVariable", "groupingVariables"), unlist = TRUE)
     thisLengthDistributionData[, c(dataVariable) := sum(x = get(dataVariable) * get(weightingVariable)), by = by]
-    
-    # Add the number of assigned hauls par PSU, and the number of assigned hauls with length distribution for each species
-    thisLengthDistributionData[, NumberOfAssignedHauls := length(unique(Haul))]
-    thisLengthDistributionData[, HasAnyPositiveWeightedNumber := any(!is.na(WeightedNumber) & (WeightedNumber > 0) %in% TRUE), by = c("Haul", "SpeciesCategory")]
-    thisLengthDistributionData[, ValidHaul := ifelse(HasAnyPositiveWeightedNumber, Haul, NA)]
-    thisLengthDistributionData[, NumberOfAssignedHaulsWithCatch := length(unique(stats::na.omit(ValidHaul))), by = "SpeciesCategory"]
     
     # Extract only the relevant columns:
     ###formatOutput(thisLengthDistributionData, dataType = "AssignmentLengthDistributionData", keep.all = FALSE, allow.missing = TRUE)

--- a/man/MeanDensity.Rd
+++ b/man/MeanDensity.Rd
@@ -10,7 +10,7 @@ MeanDensity(DensityData)
 \item{DensityData}{The \code{\link{DensityData}} data.}
 }
 \description{
-This function calculates the weighted average of the density in each stratum (or possibly in each PSU, which impies returning the input DensityData unchanged). The weights are effective log distance for acoustic density and number of hauls ??????????????????? per PSU for swept area density.
+This function calculates the weighted average of the density in each stratum (or possibly in each PSU, which implies returning the input DensityData unchanged). The weights are effective log distance for acoustic density and number of stations per biotic PSU for swept area density.
 }
 \seealso{
 See \code{\link{AcousticDensity}} for acoustic density and  \code{\link{SweptAreaDensity}} for swept-area density.


### PR DESCRIPTION
…r by multiplying by WeightingFactor in getAssignmentLengthDistributionDataOne(), so that warning "... assigned hauls with no length measured individuals ..." will not occur due to random sampling of hauls in RstoxFramework::Bootstrap()