### PR TITLE
Eased warning for single unique value in bootstrap report to when the…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.8.0
-Date: 2022-03-31
+Version: 1.9.0
+Date: 2022-04-01
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# RstoxBase v1.9.0 (2022-04-01)
+* Eased warning for single unique value in bootstrap report to when the mean is 0.
+* Bypassed warning for manual BioticPSU not yet being implemented when UseProcessData = TRUE.
+
+
 # RstoxBase v1.8.0 (2022-03-31)
 * Final version for StoX 3.4.0.
 

--- a/R/Define.R
+++ b/R/Define.R
@@ -475,6 +475,10 @@ DefineBioticPSU <- function(
     FileName = character()
 ) {
     
+    if(UseProcessData) {
+        return(processData)
+    }
+    
     # Get the DefinitionMethod:
     #DefinitionMethod <- match.arg(DefinitionMethod)
     DefinitionMethod <- if(isEmptyString(DefinitionMethod)) "" else match.arg(DefinitionMethod)

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -795,7 +795,9 @@ summaryStox <- function(x, na.rm = FALSE) {
     )
     # Set 0 sd to NA, with a warning assuming that this is a result of only one PSU selected in the stratum:
     if(!is.na(out["sd"]) && out["sd"] == 0) {
-        warning("StoX: Standard deviation 0 was set to NA. StoX does not accept standard deviation 0, as it is either a sign of insufficient number of bootstraps; only one value to sample from in the bootstrapping (e.g. only one station in a stratum); or 0 in all bootstrap runs, which occurs e.g. if a length group is present in the survey but not in the stratum in question, causing 0 for all bootstrap runs in that stratum.")
+        if(out["mean"] != 0) {
+            warning("StoX: Standard deviation 0 was set to NA. StoX does not accept standard deviation 0, as it is either a sign of insufficient number of bootstraps; only one value to sample from in the bootstrapping (e.g. only one station in a stratum); or 0 in all bootstrap runs, which occurs e.g. if a length group is present in the survey but not in the stratum in question, causing 0 for all bootstrap runs in that stratum.")
+        }
         out["sd"] <- NA
         out["cv"] <- NA
     }


### PR DESCRIPTION
… mean is 0. Bypassed warning for manual BioticPSU not yet being implemented when UseProcessData = TRUE.