### PR TITLE
Changed to not split NSAC = 0. Changed SplitNASC to remove rows with …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.9.5
-Date: 2022-06-19
+Version: 1.9.6
+Date: 2022-08-06
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 
@@ -42,7 +42,7 @@ Imports:
     geojsonsf (>= 2.0.0),
     ggplot2 (>= 3.0.0),
     lwgeom (>= 0.2-0),
-    RstoxData (>= 1.6.5),
+    RstoxData (>= 1.6.7),
     sf (>= 0.9.0),
     sp (>= 1.3.2),
     stringi (>= 1.4.3),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# RstoxBase v1.9.6 (2022-06-23)
+* Fixed bug in LengthDistribution() with SampleWeight or SampleCount = 0, where haulsWithInfRaisingFactor and samplesWithInfRaisingFactor were missing on line 208.
+* Changed to not split NSAC = 0. 
+* Changed SplitNASC to remove rows with NA NASC originating from missing assignment length distribution. 
+* Changed to consider species to be split that are not present in the AssignmentLengthDistribution of a NASC value to be split as WeightedNumber = 0 instead of NA. This prevents NA NASC, and doubles the previous change.
+
+
 # RstoxBase v1.9.5 (2022-06-20)
 * Fixed bug in DefineBioticAssignment() where DefinitionMethod "Stratum" failed due to unset attribute "pointLabel".
 * Added stop when project.xml file path is not set in a DefinitionMethod "ResourceFile"

--- a/R/Report.R
+++ b/R/Report.R
@@ -215,7 +215,6 @@ aggregateBaselineDataOneTable <- function(
     
     # Add a CJ operation here like in StoX 2.7 (function reportQuantityAtLevel). This needs an option, so that it is only used across bootstrap iterations:
     if(length(padWithZerosOn)) {
-        
         # Attempt to generalize the creation of the grid and filling in the data, intended for use here and for an ExpandNASC function, but the latter was abandoned, so no need to generalize:
         ### dimensionVariables <- c(GroupingVariables, padWithZerosOn)
         ### informationVariables = setdiff(names(stoxData), c(dimensionVariables, TargetVariable))
@@ -248,7 +247,7 @@ aggregateBaselineDataOneTable <- function(
         if(length(abudanceVariables)) {
             # Set all NA to 0, both those from the original stoxData and those introduced by the grid:
             replaceNAByReference(stoxData, cols = abudanceVariables, replacement = 0)
-            # Restore the NAs from the original st  oxData:
+            # Restore the NAs from the original stoxData:
             stoxData[areNA, eval(TargetVariable) := NA]
         }
     }

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -883,14 +883,29 @@ StoxDataStartMiddleStopDateTime <- function(
 #' 
 #' @export
 #' 
+#replaceNAByReference <- function(DT, cols = NULL, replacement = 0) {
+#    if(!length(cols)) {
+#        cols <- names(DT)
+#    }
+#    for (j in cols) {
+#        data.table::set(DT, which(is.na(DT[[j]]) & is.numeric(DT[[j]])), j, replacement)
+#    }
+#}
 replaceNAByReference <- function(DT, cols = NULL, replacement = 0) {
     if(!length(cols)) {
         cols <- names(DT)
     }
-    for (j in cols) {
-        data.table::set(DT, which(is.na(DT[[j]]) & is.numeric(DT[[j]])), j, replacement)
+    if(length(replacement)) {
+        if(!is.list(replacement)) {
+            replacement <- structure(list(replacement), names = RstoxData::firstClass(replacement))
+        }
+        for (j in cols) {
+            data.table::set(DT, which(is.na(DT[[j]]) & class(DT[[j]]) %in% names(replacement)), j, replacement[[RstoxData::firstClass(DT[[j]])]])
+        }
     }
 }
+
+
 
 
 detectInvalidUTF8 <- function(x) {


### PR DESCRIPTION
…NA NASC originating from missing assignment length distribution. Changed to consider species to be split that are not present in the AssignmentLengthDistribution of a NASC value to be split as WeightedNumber = 0 instead of NA. This prevnts NA NASC, and doubles the previous change.