### PR TITLE
Improved warning when EDSUs/Stations are tagged to a PSU but not pres…

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -38,20 +38,21 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
+      - name: Install MacOS dependencies
+        if: runner.os == 'macOS'
+        run: |
+          rm '/usr/local/bin/gfortran'
+          rm '/usr/local/bin/2to3'
+          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=false # This prevents Homebrew from re-installing R, which will lead to .Platform$pkgType = "source".
+          brew install gdal
+        shell: bash
+
       - name: Install dependencies
         run: |
           install.packages("remotes")
           remotes::install_deps(dependencies = TRUE)
           remotes::install_dev("pkgdown")
         shell: Rscript {0}
-
-      - name: Install MacOS dependencies
-        if: runner.os == 'macOS'
-        run: |
-          rm '/usr/local/bin/gfortran'
-          rm '/usr/local/bin/2to3'
-          brew install gdal
-        shell: bash
 
       - name: Install package
         run: R CMD INSTALL .

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.9.6
-Date: 2022-08-06
+Version: 1.9.7
+Date: 2022-08-09
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 
@@ -42,7 +42,7 @@ Imports:
     geojsonsf (>= 2.0.0),
     ggplot2 (>= 3.0.0),
     lwgeom (>= 0.2-0),
-    RstoxData (>= 1.6.7),
+    RstoxData (>= 1.6.8),
     sf (>= 0.9.0),
     sp (>= 1.3.2),
     stringi (>= 1.4.3),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
-# RstoxBase v1.9.6 (2022-06-23)
+# RstoxBase v1.9.6 (2022-08-10)
+* Improved warning when EDSUs/Stations are tagged to a PSU but not present in the data. 
+* Turned off spherical geometry with apply_and_set_use_s2_to_FALSE() when locating EDSUs/Stations in Strata. 
+* Added warning when no assigned hauls are located in any Stratum of the PSUs. 
+* Cleaned up warnings that list up Hauls, PSUs etc, so that alle use printErrorIDs(), which was siimplified.
+
+
+# RstoxBase v1.9.6 (2022-08-08)
 * Fixed bug in LengthDistribution() with SampleWeight or SampleCount = 0, where haulsWithInfRaisingFactor and samplesWithInfRaisingFactor were missing on line 208.
 * Changed to not split NSAC = 0. 
 * Changed SplitNASC to remove rows with NA NASC originating from missing assignment length distribution. 

--- a/R/Density.R
+++ b/R/Density.R
@@ -305,8 +305,8 @@ DistributeNASC <- function(
     
     if(NROW(withOnlyOneHaul)) {
         # Get the unique invalid hauls:
-        withOnlyOneHaul <- withOnlyOneHaul[, Reduce(function(...) paste(..., sep = "-"), .SD), .SDcols = resolution]
-        warning(paste("StoX: There are Stratum/PSU that have assigned ONLY ONE haul. This is in conflict with the principle of bootstrapping, and can lead to underestimation of variance in reports from bootstrap. The following Stratum/PSU have only one assigned haul:", paste(withOnlyOneHaul, collapse = "\n\t"), sep = "\n\t"))
+        withOnlyOneHaul <- withOnlyOneHaul[, Reduce(function(...) paste(..., sep = ","), .SD), .SDcols = resolution]
+        warning(paste("StoX: There are Stratum,PSU that have assigned ONLY ONE haul. This is in conflict with the principle of bootstrapping, and can lead to underestimation of variance in reports from bootstrap. The following Stratum,PSU have only one assigned haul:", printErrorIDs(withOnlyOneHaul)))
     }
     
     # Add a warning if any WeightedNumber are NA while NASC > 0:

--- a/R/LengthDistribution.R
+++ b/R/LengthDistribution.R
@@ -94,7 +94,7 @@ LengthDistribution <- function(
     # Check for missing individuals due to positive sample number but no individuals of that sample:
     atMissingIndividual <- StoxBioticDataMerged[,  which(is.na(IndividualKey) & (SampleWeight > 0 | SampleNumber > 0))]
     if(length(atMissingIndividual)) {
-        warning("StoX: The following Samples have positive SampleNumber but no individuals, which is indicative of error in the input biotic data. This results in positive WeightedNumber while IndividualTotalLength is missing, which may propagate thoughout the StoX project:\n", printErrorIDs(errorName = "Sample", errorIDs = StoxBioticDataMerged[atMissingIndividual, Sample])
+        warning("StoX: The following Samples have positive SampleNumber but no individuals, which is indicative of error in the input biotic data. This results in positive WeightedNumber while IndividualTotalLength is missing, which may propagate thoughout the StoX project:\n", printErrorIDs(StoxBioticDataMerged[atMissingIndividual, Sample])
         )
     }
     
@@ -262,21 +262,23 @@ getBadRaisingFactorError <- function(badness, hasBad, LengthDistributionData) {
     if(badness == "NA") {
         paste0(
             "StoX: Invalid Sample error: There are ", length(badHauls), " samples of ", length(badSamples), " hauls with missing (NA) raising factor, which is an indication of at least one NA in each of the pairs CatchFractionWeight/SampleWeight and CatchFractionNumber/SampleNumber. This is considered by StoX as an error in the data, making it impossible to calculate length distribution. The exception is for LengthDistributionType = \"Percent\" when there is only one sample, in which case NA raising factors are set to 1. These errors should be corrected in the database holding the input data.\n", 
-            paste0("The following lists the samples with ", badness, " raising factor:\n"), 
-            printErrorIDs(errorName = "Sample", errorIDs = badSamples)
+            paste0("The following lists the Samples with ", badness, " raising factor:\n"), 
+            printErrorIDs(badSamples)
         )
     }
     else {
         paste0(
             "StoX: Invalid Sample error: There are ", length(badSamples), " samples of ", length(badHauls), " hauls with infinite raising factor, which is an indication SampleWeight or SampleNumber are 0 for those samples and will lead to Inf values in the length distribution. This is considered by StoX as an error in the data, making it impossible to calculate length distribution. These errors should be corrected in the database holding the input data.\n", 
-            paste0("The following lists the samples with ", badness, " raising factor:\n"), 
-            printErrorIDs(errorName = "Sample", errorIDs = badSamples)
+            paste0("The following lists the Samples with ", badness, " raising factor:\n"), 
+            printErrorIDs(badSamples)
         )
     }
 }
 
-printErrorIDs <- function(errorName, errorIDs, bullet = "* ", sep = ": ", collapse = "\n") {
-    out <- paste0(paste0(bullet, errorName, sep, errorIDs, collapse = collapse), collapse)
+#printErrorIDs <- function(errorName, errorIDs, bullet = "* ", sep = ": ", collapse = "\n") {
+printErrorIDs <- function(errorIDs, collapse = "\n\t") {
+    #paste0(paste0(bullet, errorName, sep, errorIDs, collapse = collapse), collapse)
+    paste0(collapse,  paste0(errorIDs, collapse = collapse))
 }
 
 
@@ -971,6 +973,10 @@ AssignmentLengthDistribution <- function(LengthDistributionData, BioticAssignmen
     ### if(!isLengthDistributionType(LengthDistributionData, "Percent")) {
     ###     stop("LengthDistributionData used as input to AssignmentLengthDistribution() must be of LengthDistributionType \"Percent\"")
     ### }
+    
+    if(!NROW(BioticAssignment)) {
+        stop("BioticAssignment is empty. No AssignmentLengthDistributionData can be calculated.")
+    }
     
     # Determine assignment IDs:
     BioticAssignmentCollapsed <- BioticAssignment[, .(assignmentPasted = paste0(paste(Haul, WeightingFactor, sep = ",", collapse = "\n"), "\n")), by = c("Stratum", "PSU", "Layer")]

--- a/R/Spatial.R
+++ b/R/Spatial.R
@@ -807,11 +807,11 @@ locateInStratum <- function(points, stratumPolygon, locationProjection = c("lonl
     at0Strata <- numberOfStrata == 0
     if(any(atMultipleStrata)) {
         bad <- pointNames[atMultipleStrata]
-        warning("StoX: The following ", pointLabel, " was detected in more than one stratum:\n", printErrorIDs(errorName = pointLabel, errorIDs = bad))
+        warning("StoX: The following ", pointLabel, " was detected in more than one stratum:\n", printErrorIDs(bad))
     }
     if(any(at0Strata)) {
         bad <- pointNames[at0Strata]
-        warning("StoX: The following ", pointLabel, " was not detected in any stratum:\n", printErrorIDs(errorName = pointLabel, errorIDs = bad))
+        warning("StoX: The following ", pointLabel, " was not detected in any stratum:\n", printErrorIDs(bad))
     }
     
     ind <- lapply(hits, utils::head, 1)

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -507,7 +507,8 @@ applyMeanToData <- function(data, dataType, targetResolution = "PSU") {
     extract <- c(
         horizontalResolution, 
         targetHorizontalResolution, 
-        weightingVariable
+        weightingVariable, 
+        dataVariable
     )
     extract <- unique(extract)
     
@@ -517,7 +518,8 @@ applyMeanToData <- function(data, dataType, targetResolution = "PSU") {
     
     # Then sum the weights by the next resolution, PSU for mean of stations/EDSUs and Stratum for mean of PSUs:
     # Use utils::tail(horizontalResolution, 1) here to get the Station/Haul/PSU:
-    naWeights <- summedWeighting[, is.na(get(weightingVariable)) & !is.na(get(utils::tail(horizontalResolution, 1)))]
+    # 2022-08-08: Added !is.na(get(dataVariable)) here to avoid this warning for rows with e.g. missing NACS:
+    naWeights <- summedWeighting[, is.na(get(weightingVariable)) & !is.na(get(utils::tail(horizontalResolution, 1))) & !is.na(get(dataVariable))]
     if(any(naWeights)) {
         warning("StoX: There are missing values for ", weightingVariable, ". This can result in missing values in ", targetDataType, ". The following ", horizontalResolution, " have missing ", weightingVariable, ":\n\t", paste(summedWeighting[[utils::tail(horizontalResolution, 1)]][naWeights], collapse = "\n\t"))
     }


### PR DESCRIPTION
…ent in the data. Turned off spherical geometry with apply_and_set_use_s2_to_FALSE() when locating EDSUs/Stations in Strata. Added warning when no assigned hauls are located in any Stratum of the PSUs. Cleaned up warnings that list up Hauls, PSUs etc, so that alle use printErrorIDs(), which was siimplified.