### PR TITLE
Removed from the GUI the warning for EDSUs/Stations detected in more …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RstoxBase
-Version: 1.9.8
-Date: 2022-08-10
+Version: 1.10.0
+Date: 2022-08-12
 Title: Base StoX Functions
 Authors@R: c(
   person(given = "Arne Johannes", 
@@ -42,7 +42,7 @@ Imports:
     geojsonsf (>= 2.0.0),
     ggplot2 (>= 3.0.0),
     lwgeom (>= 0.2-0),
-    RstoxData (>= 1.6.8),
+    RstoxData (>= 1.7.0),
     sf (>= 0.9.0),
     sp (>= 1.3.2),
     stringi (>= 1.4.3),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,18 @@
+# RstoxBase v1.10.0 (2022-08-12)
+* Removed from the GUI the warning for EDSUs/Stations detected in more than one stratum. 
+* Added warning is all EDSUs included in the AcousticPSU proecss data are missing in the StoxAcousticData, which is an indication of new data in an old project where AcousticPSUs should be re-defined from scratch. 
+* Start of using semantic versioning (https://semver.org/). Before this release the two first version numbers represented the major and minor release number, in accordance with semantic versioning, whereas the third version number identified test versions. The major and minor releases (versions ending with 0.0 or 0) were considered as official versions. From this release and onwards, the third version number will represent patches (bug fixes), and are to be considered equally official as the major and minor releases. In fact, as patches are restricted to fixing bugs and not adding new functionality, the latest patch will be the recommended version."
+
+
+# RstoxBase v1.9.8 (2022-08-10)
+* Fixed bug in applyMeanToData() introduced in RstoxBase 1.9.8.
+
+
 # RstoxBase v1.9.7 (2022-08-10)
 * Improved warning when EDSUs/Stations are tagged to a PSU but not present in the data. 
 * Turned off spherical geometry with apply_and_set_use_s2_to_FALSE() when locating EDSUs/Stations in Strata. 
 * Added warning when no assigned hauls are located in any Stratum of the PSUs. 
-* Cleaned up warnings that list up Hauls, PSUs etc, so that alle use printErrorIDs(), which was siimplified.
+* Cleaned up warnings that list up Hauls, PSUs etc, so that alle use printErrorIDs(), which was simplified.
 
 
 # RstoxBase v1.9.6 (2022-08-08)

--- a/R/Spatial.R
+++ b/R/Spatial.R
@@ -807,7 +807,9 @@ locateInStratum <- function(points, stratumPolygon, locationProjection = c("lonl
     at0Strata <- numberOfStrata == 0
     if(any(atMultipleStrata)) {
         bad <- pointNames[atMultipleStrata]
-        warning("StoX: The following ", pointLabel, " was detected in more than one stratum:\n", printErrorIDs(bad))
+        # 2022-08-11: Removed this warning from the GUI:
+        #warning("StoX: The following ", pointLabel, " was detected in more than one stratum. The first stratum was selected:\n", printErrorIDs(bad))
+        warning("The following ", pointLabel, " was detected in more than one stratum. The first stratum was selected:\n", printErrorIDs(bad))
     }
     if(any(at0Strata)) {
         bad <- pointNames[at0Strata]


### PR DESCRIPTION
…than one stratum. Added warning is all EDSUs included in the AcousticPSU proecss data are missing in the StoxAcousticData, which is an indication of new data in an old project where AcousticPSUs should be re-defined from scratch. Start of using semantic versioning (https://semver.org/). Before this release the two first version numbers represented the major and minor release number, in accordance with semantic versioning, whereas the third version number identified test versions. The major and minor releases (versions ending with 0.0 or 0) were considered as official versions. From this release and onwards, the third version number will represent patches (bug fixes), and are to be considered equally official as the major and minor releases. In fact, as patches are restricted to fixing bugs and not adding new functionality, the latest patch will be the recommended version.